### PR TITLE
Swap timers 1 and 3 so that tone() plays on first channel

### DIFF
--- a/src/ArduboyPlaytune.cpp
+++ b/src/ArduboyPlaytune.cpp
@@ -1,7 +1,7 @@
 #include "ArduboyPlaytune.h"
 #include <avr/power.h>
 
-const byte PROGMEM tune_pin_to_timer_PGM[] = { 3, 1 };
+const byte PROGMEM tune_pin_to_timer_PGM[] = { 1, 3 };
 volatile byte *_tunes_timer1_pin_port;
 volatile byte _tunes_timer1_pin_mask;
 volatile int32_t timer1_toggle_count;


### PR DESCRIPTION
As tone() always uses Timer 1, no sound is outputted when only the first channel is initialised (for example pin 5).

This can be solved by swapping the timers in tune_pin_to_timer_PGM[], so that the first channel corresponds to Timer 1.

Can anyone test that on an Arduboy Dev Kit and an Arduboy 1.0?
