### PR TITLE
Add support for output disable/enable (mute)

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,15 @@
+(C) Copyright 2016, Chris J. Martinez, Kevin Bates, Josh Goebel, Scott Allen
+Based on work (C) Copyright 2011, 2015, Len Shustek
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of version 3 of the GNU General Public License as
+published by the Free Software Foundation at http://www.gnu.org/licenses,
+with Additional Permissions under term 7(b) that the original copyright
+notice and author attibution must be preserved and under term 7(c) that
+modified versions be marked as different from the original.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ There is no volume modulation. All notes and tones are played as square waves by
 ## The Score bytestream
 
 Scores **must** be stored in Flash memory (using PROGMEM), as an array of bytes. E.g.:
+
 `const byte score[] PROGMEM = {0x90,83, 0,75, 0x80, 0x90,88, 0,225, 0x80, 0xf0};`
 
 The bytestream is a series of commands that can turn notes on and off, and can start a waiting period until the next note change. Here are the details, with numbers shown in hexadecimal.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,59 @@
 # ArduboyPlaytune
 
-The ArduboyPlaytune library. Based on the [arduino-playtune](https://github.com/LenShustek/arduino-playtune) library.
+The ArduboyPlaytune library.
+Based on the [arduino-playtune](https://github.com/LenShustek/arduino-playtune) library.
+
+ArduboyPlaytune interprets a sequence of simple commands ("note on", "note off", and "wait") that represents a one or two part musical score without volume modulation. Once the score has started playing, background interrupt routines use the Arduino counters to generate notes in sequence at the right time. Two notes can play simultaneously. A separate open-source project called [MIDITONES](https://github.com/lenshustek/miditones) can generate the command sequence from a standard MIDI file.
+
+ArduboyPlaytune can also play individual tones on the second channel, given a frequency and duration. If a score is playing when the *tone()* function is called, the tone will replace any notes assigned to the second channel for the tone's duration. By default, notes on the first channel will continue to play during the tone. By calling function
+*toneMutesScore(boolean mute)* with parameter *mute* set to *true*,
+the first channel will also be muted during a tone, so only the tone will sound.
+
+Once a score or tone starts playing, all of the processing happens in interrupt routines, so any other "real" program can be running at the same time, as long as it doesn't use the timers or output pins that ArduboyPlaytune is using.
+
+There is no volume modulation. All notes and tones are played as square waves by driving the pins high and low, which makes some scores sound strange. This is definitely not a high-quality synthesizer.
+
+## The Score bytestream
+
+Scores **must** be stored in Flash memory (using PROGMEM), as an array of bytes. E.g.:
+`const byte score[] PROGMEM = {0x90,83, 0,75, 0x80, 0x90,88, 0,225, 0x80, 0xf0};`
+
+The bytestream is a series of commands that can turn notes on and off, and can start a waiting period until the next note change. Here are the details, with numbers shown in hexadecimal.
+
+If the high-order bit of the byte is 1, then it is one of the following commands:
+
+    9t nn  Start playing note nn on channel t. Channels are numbered
+           starting with 0. The notes numbers are the MIDI numbers for the chromatic
+           scale, with decimal 60 being Middle C, and decimal 69 being Middle A
+           at 440 Hz. The highest note is decimal 127 at about 12,544 Hz.
+
+    8t     Stop playing the note on channel t.
+
+    F0     End of score: stop playing.
+
+    E0     End of score: start playing again from the beginning.
+
+If the high-order bit of the byte is 0, it is a command to wait. The other 7 bits and the 8 bits of the following byte are interpreted as a 15-bit big-endian integer that is the number of milliseconds to wait before processing the next command.
+
+For example,
+
+    07 D0
+
+would cause a wait of 0x07d0 = 2000 decimal milliseconds or 2 seconds. Any tones that were playing before the wait command will continue to play.
+
+## Audio Mute Control
+
+ArduboyPlaytune has the ability to mute the sound output based on a boolean value returned by a provided function. A pointer to this function is passed as a parameter to the ArduboyPlaytune class constructor. The function is called by ArduboyPlaytune to determine whether to actually output sound. If sound is muted, ArduboyPlaytune still goes through the motions of playing scores and tones but it doesn't actually toggle the pins. If muting is not required, a function that just returns *true* should be provided.
+
+The function is called and tested at the point where a note or tone would begin playing. Any sounding notes will continue to play until the current wait time expires. A sounding tone will play for its duration. Sound output won't mute or start in the middle of a score wait or tone duration.
+
+## Using a single pin
+
+If only one pin is available for sound output (such as with the Arduboy DevKit) it's still possible to play both a score and tones, even though tones are always played on the second channel. This is done by using the same pin number to initialise both channels. The first channel of a score (only) and tones will then both output on the same pin.
+
+When score notes and tones toggle the pin at the same time some very strange sounds are produced. To prevent this, function *toneMutesScore(true)* should be called during initialisation, so the score is muted when a tone is sounding.
+
+## User Interface
+
+Functions in this library, that are available for use by sketches, are documented in file *ArduboyPlaytune.h*
+

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ would cause a wait of 0x07d0 = 2000 decimal milliseconds or 2 seconds. Any tones
 
 ArduboyPlaytune has the ability to mute the sound output based on a boolean value returned by a provided function. A pointer to this function is passed as a parameter to the ArduboyPlaytune class constructor. The function is called by ArduboyPlaytune to determine whether to actually output sound. If sound is muted, ArduboyPlaytune still goes through the motions of playing scores and tones but it doesn't actually toggle the pins. If muting is not required, a function that just returns *true* should be provided.
 
-The function is called and tested at the point where a note or tone would begin playing. Any sounding notes will continue to play until the current wait time expires. A sounding tone will play for its duration. Sound output won't mute or start in the middle of a score wait or tone duration.
+The function is called and tested at the point where a note or tone would begin playing. Any sounding notes will continue to play until the current wait time expires. A sounding tone will play for its duration. Sound output won't mute or start in the middle of a score wait or tone duration. Note that the function will be called from within a timer interrupt service routine, at the start of each score note, so it should be as fast as possible.
 
 ## Using a single pin
 

--- a/README.md
+++ b/README.md
@@ -58,3 +58,15 @@ When score notes and tones toggle the pin at the same time some very strange sou
 
 Functions in this library, that are available for use by sketches, are documented in file *ArduboyPlaytune.h*
 
+## Arduboy specific information
+
+- If using the Arduboy library or a library derived from it, *audio.enabled()* is appropriate to use as the *mute* function passed to the ArduboyPlaytune constructor. For example:
+
+```cpp
+Arduboy arduboy;
+ArduboyPlaytune tunes(arduboy.audio.enabled);
+```
+- ArduboyPlaytune uses timer 1, which is also used for PWM on the pins used for the Arduboy's RGB LED. Using ArduboyPlaytune and attempting to control the RGB LED using PWM, such as with *setRGBled()*, may cause problems. Controlling the RGB LED using standard digital I/O will work without conflicts.
+
+----------
+

--- a/extras/docs/FILE_DESCRIPTIONS.md
+++ b/extras/docs/FILE_DESCRIPTIONS.md
@@ -1,0 +1,22 @@
+# File Descriptions
+
+Documentation for files contained in this repository which aren't self explanatory.
+
+### /library.properties
+
+Provides information so that this library can be installed and updated in the Arduino IDE using the [Library Manager](https://www.arduino.cc/en/Guide/Libraries#toc3).
+
+The value of *version* must be set to the latest stable tagged release. This should be changed and commited just before tagging the new release.
+
+See the [Arduino IDE 1.5: Library specification](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification) for details.
+
+### /library.json
+
+This JSON file is a manifest used by the [PlatformIO IDE](http://platformio.org/) to make this library available in its [Library Manager](http://docs.platformio.org/en/latest/librarymanager/index.html).
+
+The value of *version* must be set to the latest stable tagged release. This should be changed and commited just before tagging the new release.
+
+See the [PlatformIO library.json](http://docs.platformio.org/en/latest/librarymanager/config.html) documentation for details.
+
+----------
+

--- a/keywords.txt
+++ b/keywords.txt
@@ -1,0 +1,22 @@
+#########################################
+# Syntax Coloring Map For ArduboyPlaytune
+#########################################
+
+#########################################
+# Datatypes (KEYWORD1)
+#########################################
+
+ArduboyPlaytune	KEYWORD1
+
+#########################################
+# Methods and Functions (KEYWORD2)
+#########################################
+
+closeChannels	KEYWORD2
+initChannel	KEYWORD2
+playing	KEYWORD2
+playScore	KEYWORD2
+stopScore	KEYWORD2
+tone	KEYWORD2
+toneMutesScore	KEYWORD2
+

--- a/library.json
+++ b/library.json
@@ -1,0 +1,14 @@
+{
+    "name": "ArduboyPlaytune",
+    "keywords": "arduboy, game, sound, music",
+    "description": "A library for playing musical scores and tones that is compatible with the Arduboy game system",
+    "repository":
+    {
+        "type": "git",
+        "url": "https://github.com/Arduboy/ArduboyPlaytune.git"
+    },
+    "version": "1.0.0",
+    "exclude": "extras",
+    "frameworks": "arduino",
+    "platforms": "atmelavr"
+}

--- a/library.properties
+++ b/library.properties
@@ -1,8 +1,8 @@
 name=ArduboyPlaytune
-version=0.9.0
+version=1.0.0
 author=Len Shustek, Chris J. Martinez, Kevin Bates, Josh Goebel, Scott Allen
 maintainer=Ross O. Shoger ros@arduboy.com
-sentence=Fork of the Playtune library that is compatible with Arduboy.
+sentence=A library for playing musical scores and tones that is compatible with the Arduboy game system.
 paragraph=Plays one or two part scores, and tones. Driven by interrupts, so audio plays in the background while the "real" program runs in the foreground.
 category=Other
 url=https://github.com/arduboy/ArduboyPlaytune

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=ArduboyPlaytune
-version=0.9
-author=Chris J. Martinez, Kevin Bates, Josh Goebel
+version=0.9.0
+author=Len Shustek, Chris J. Martinez, Kevin Bates, Josh Goebel, Scott Allen
 maintainer=Ross O. Shoger ros@arduboy.com
 sentence=Fork of the Playtune library that is compatible with Arduboy.
-paragraph=Fork of the Playtune library that is compatible with Arduboy.
+paragraph=Plays one or two part scores, and tones. Driven by interrupts, so audio plays in the background while the "real" program runs in the foreground.
 category=Other
 url=https://github.com/arduboy/ArduboyPlaytune
 architectures=avr

--- a/src/ArduboyPlaytune.h
+++ b/src/ArduboyPlaytune.h
@@ -1,10 +1,40 @@
+/*****************************************************************************
+* ArduboyPlaytune
+*
+* Plays a one or two part musical score and generates tones.
+*
+* Derived from:
+* Playtune: An Arduino tune player library
+* https://github.com/LenShustek/arduino-playtune
+*
+* Modified to work well with the Arduboy game system
+* https://www.arduboy.com/
+*
+*  (C) Copyright 2016, Chris J. Martinez, Kevin Bates, Josh Goebel, Scott Allen
+*  Based on work (C) Copyright 2011, 2015, Len Shustek
+*
+*  This program is free software: you can redistribute it and/or modify
+*  it under the terms of version 3 of the GNU General Public License as
+*  published by the Free Software Foundation at http://www.gnu.org/licenses,
+*  with Additional Permissions under term 7(b) that the original copyright
+*  notice and author attibution must be preserved and under term 7(c) that
+*  modified versions be marked as different from the original.
+*
+*  This program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU General Public License for more details.
+*
+*  This was inspired by and adapted from "A Tone Generator Library",
+*  written by Brett Hagman, http://www.roguerobotics.com/
+*
+*****************************************************************************/
+
 #ifndef ARDUBOY_PLAYTUNE_H
 #define ARDUBOY_PLAYTUNE_H
 
 #include <Arduino.h>
-#include <EEPROM.h>
 #include <avr/pgmspace.h>
-#include <avr/power.h>
 
 #define AVAILABLE_TIMERS  2
 #define TUNE_OP_PLAYNOTE  0x90  /* play a note: low nibble is generator #, note is next byte */
@@ -15,33 +45,75 @@
 class ArduboyPlaytune
 {
 public:
-  // Playtune Functions
+  /// The class constructor.
+  /**
+   * The function passed to the constructor must return "true", if sounds
+   * should be played, or "false" if all sound should be muted. If muting
+   * control isn't required, provide a pointer to a function that always
+   * returns "true".
+   */
+  ArduboyPlaytune(boolean (*outEn)());
 
-  /// Assign a timer to an output pin.
+  /// Assign an output pin to a score channel.
+  /**
+   * Each time this function is called the next score channel is assigned
+   * to the provided pin number, so it should be called once or twice.
+   * If the tone() function is to be used, the second channel must be
+   * initialised since tones are alway played on it.
+   *
+   * The same pin number can be used for both channels, in which case only the
+   * first score channel will be played and tones will play on the same pin.
+   * Function toneMutesScore(true) can be use to prevent the strange sounds
+   * that occur from using the same pin for both the score and tones.
+   */
   void static initChannel(byte pin);
 
-  /// Start playing a polyphonic score.
+  /// Start playing the provided score.
+  /**
+   * Any notes for channels above the first two will be ignored.
+   */
   void playScore(const byte *score);
 
   /// Stop playing the score.
   void stopScore();
 
-  /// Delay in milliseconds.
-  void delay(unsigned msec);
-
-  /// Stop all timers.
+  /// Close both channels.
+  /**
+   * After calling this function, use function initChannel() must be called to
+   * reassign pins to channels.
+   */
   void closeChannels();
 
-  bool playing();
+  /// Returns "true" if a score is playing.
+  boolean playing();
+
+  /// Play a tone of a given frequency and duration on the second channel.
+  /**
+   * If a score is playing that uses the second channel, the notes for that
+   * channel stop for the duration of the tone. Score notes on the
+   * first channel continue to play unless toneMutesScore(true) has been
+   * called.
+   */
   void tone(unsigned int frequency, unsigned long duration);
 
-  // called via interrupt
-  void static step();
-  void static soundOutput();
+  /// Control whether playing a tone mutes the first score channel.
+  /**
+   * If called with "true" the first channel will be muted when a tone
+   * is playing. (The second channel is always muted since the tone plays
+   * on it.)
+   *
+   * If called with "false" (the default) the first channel will continue to
+   * play when a tone is playing.
+   */
+  void toneMutesScore(boolean mute);
 
 private:
-  void static playNote (byte chan, byte note);
-  void static stopNote (byte chan);
+  void static playNote(byte chan, byte note);
+  void static stopNote(byte chan);
+
+public:
+  // called via interrupt. Should not be called by a program.
+  void static step();
 };
 
 #endif

--- a/src/ArduboyPlaytune.h
+++ b/src/ArduboyPlaytune.h
@@ -51,6 +51,8 @@ public:
    * should be played, or "false" if all sound should be muted. If muting
    * control isn't required, provide a pointer to a function that always
    * returns "true".
+   * This function will be called from the timer interrupt service routine,
+   * at the start of each score note, so it should be as fast as possible.
    */
   ArduboyPlaytune(boolean (*outEn)());
 


### PR DESCRIPTION
Constructor now requires a parameter which is a pointer to a function which
returns "true" if sound is to be played or "false" if sound should be muted.

Also:
- Additions and changes for improved handling of tones.
- Updated README.md and documentation within the source.
- Added LICENSE.txt and keywords.txt files.
- Added new authors, enhanced the description, and changed version from
  0.9 to 0.9.0 in the library.properties file.

I considered making this even more Arduboy specific by having the Arduboy library object passed to the constructor, instead of a pointer to a function that returns the mute state. This would allow using _audio.enabled()_ directly for muting. It could also use the defined _PIN_SPEAKER_1_ and _PIN_SPEAKER_2_ to set the pin numbers, so the user could just specify "1" or "2" for _initChannel()_.

However, the way it is now isn't really that much more difficult to use, if at all, and the library remains more generic. It could be used by any Arduino project, not just the Arduboy, and I've written the documentation with this in mind.

I've written an [_ArduboyPlaytuneTest.ino_](https://gist.github.com/MLXXXp/21aee6e346c9ef17be19f43f4e9ed464) sketch for testing, which can be used with my proposed [_Ardyboy2_ library](https://github.com/MLXXXp/Arduboy2) or V1.2 of the [_Arduboy_ library](https://github.com/Arduboy/Arduboy). To use it with Arduboy library V1.2 just change _Arduboy2_ to _Arduboy_.
